### PR TITLE
Add CRUD for service budgets and services

### DIFF
--- a/compu_click.sql
+++ b/compu_click.sql
@@ -2555,6 +2555,63 @@ ALTER TABLE `proyectos`
 ALTER TABLE `usuario`
   ADD CONSTRAINT `funcionario_usuario_fk` FOREIGN KEY (`cod_funcionario`) REFERENCES `funcionario` (`cod_funcionario`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   ADD CONSTRAINT `permiso_usuario_fk` FOREIGN KEY (`cod_permiso`) REFERENCES `permiso` (`cod_permiso`) ON DELETE NO ACTION ON UPDATE NO ACTION;
+-- --------------------------------------------------------
+-- Nuevas tablas para el módulo de servicios
+-- --------------------------------------------------------
+
+CREATE TABLE `presupuestos` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `cliente_id` int(11) NOT NULL,
+  `fecha_emision` date NOT NULL,
+  `fecha_vencimiento` date NOT NULL,
+  `total_estimado` decimal(10,2) NOT NULL,
+  `estado` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
+  `observaciones` text COLLATE utf8_unicode_ci,
+  PRIMARY KEY (`id`),
+  KEY `cliente_id` (`cliente_id`),
+  CONSTRAINT `presupuestos_cliente_fk` FOREIGN KEY (`cliente_id`) REFERENCES `cliente_1` (`cod_cliente`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+CREATE TABLE `detalle_presupuesto` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `presupuesto_id` int(11) NOT NULL,
+  `descripcion` text COLLATE utf8_unicode_ci NOT NULL,
+  `cantidad` int(11) NOT NULL,
+  `precio_unitario` decimal(10,2) NOT NULL,
+  `subtotal` decimal(10,2) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `presupuesto_id` (`presupuesto_id`),
+  CONSTRAINT `detalle_presupuesto_presupuesto_fk` FOREIGN KEY (`presupuesto_id`) REFERENCES `presupuestos` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+CREATE TABLE `servicios` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `cliente_id` int(11) NOT NULL,
+  `presupuesto_id` int(11) DEFAULT NULL,
+  `fecha_inicio` date NOT NULL,
+  `fecha_fin` date DEFAULT NULL,
+  `estado` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
+  `descripcion` text COLLATE utf8_unicode_ci,
+  `costo_final` decimal(10,2) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `cliente_id` (`cliente_id`),
+  KEY `presupuesto_id` (`presupuesto_id`),
+  CONSTRAINT `servicios_cliente_fk` FOREIGN KEY (`cliente_id`) REFERENCES `cliente_1` (`cod_cliente`),
+  CONSTRAINT `servicios_presupuesto_fk` FOREIGN KEY (`presupuesto_id`) REFERENCES `presupuestos` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+CREATE TABLE `detalle_servicio` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `servicio_id` int(11) NOT NULL,
+  `descripcion` text COLLATE utf8_unicode_ci NOT NULL,
+  `cantidad` int(11) NOT NULL,
+  `costo_unitario` decimal(10,2) NOT NULL,
+  `subtotal` decimal(10,2) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `servicio_id` (`servicio_id`),
+  CONSTRAINT `detalle_servicio_servicio_fk` FOREIGN KEY (`servicio_id`) REFERENCES `servicios` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/controladores/servicio.php
+++ b/controladores/servicio.php
@@ -1,0 +1,77 @@
+<?php
+
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    guardar($_POST['guardar']);
+}
+
+function guardar($lista) {
+    $json_datos = json_decode($lista, true);
+    $db = new DB();
+    $query = $db->conectar()->prepare("INSERT INTO servicios
+        (cliente_id, presupuesto_id, fecha_inicio, fecha_fin, estado, descripcion, costo_final)
+        VALUES (:cliente_id, :presupuesto_id, :fecha_inicio, :fecha_fin, :estado, :descripcion, :costo_final)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['leer'])) {
+    leer();
+}
+
+function leer() {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT * FROM servicios");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+}
+
+if (isset($_POST['id'])) {
+    id($_POST['id']);
+}
+
+function id($id) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT * FROM servicios WHERE id = $id");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+}
+
+if (isset($_POST['actualizar'])) {
+    actualizar($_POST['actualizar']);
+}
+
+function actualizar($lista) {
+    $json_datos = json_decode($lista, true);
+    $db = new DB();
+    $query = $db->conectar()->prepare("UPDATE servicios SET
+        cliente_id=:cliente_id,
+        presupuesto_id=:presupuesto_id,
+        fecha_inicio=:fecha_inicio,
+        fecha_fin=:fecha_fin,
+        estado=:estado,
+        descripcion=:descripcion,
+        costo_final=:costo_final
+        WHERE id=:id");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['eliminar'])) {
+    eliminar($_POST['eliminar']);
+}
+
+function eliminar($id) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("DELETE FROM servicios WHERE id = $id");
+    $query->execute();
+}
+
+?>

--- a/controladores/servicio_detalle.php
+++ b/controladores/servicio_detalle.php
@@ -1,0 +1,75 @@
+<?php
+
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    guardar($_POST['guardar']);
+}
+
+function guardar($lista) {
+    $json_datos = json_decode($lista, true);
+    $db = new DB();
+    $query = $db->conectar()->prepare("INSERT INTO detalle_servicio
+        (servicio_id, descripcion, cantidad, costo_unitario, subtotal)
+        VALUES (:servicio_id, :descripcion, :cantidad, :costo_unitario, :subtotal)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['leer'])) {
+    leer();
+}
+
+function leer() {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT * FROM detalle_servicio");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+}
+
+if (isset($_POST['id'])) {
+    id($_POST['id']);
+}
+
+function id($id) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT * FROM detalle_servicio WHERE id = $id");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+}
+
+if (isset($_POST['actualizar'])) {
+    actualizar($_POST['actualizar']);
+}
+
+function actualizar($lista) {
+    $json_datos = json_decode($lista, true);
+    $db = new DB();
+    $query = $db->conectar()->prepare("UPDATE detalle_servicio SET
+        servicio_id=:servicio_id,
+        descripcion=:descripcion,
+        cantidad=:cantidad,
+        costo_unitario=:costo_unitario,
+        subtotal=:subtotal
+        WHERE id=:id");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['eliminar'])) {
+    eliminar($_POST['eliminar']);
+}
+
+function eliminar($id) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("DELETE FROM detalle_servicio WHERE id = $id");
+    $query->execute();
+}
+
+?>

--- a/controladores/servicio_presupuesto.php
+++ b/controladores/servicio_presupuesto.php
@@ -1,0 +1,76 @@
+<?php
+
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    guardar($_POST['guardar']);
+}
+
+function guardar($lista) {
+    $json_datos = json_decode($lista, true);
+    $db = new DB();
+    $query = $db->conectar()->prepare("INSERT INTO presupuestos
+        (cliente_id, fecha_emision, fecha_vencimiento, total_estimado, estado, observaciones)
+        VALUES (:cliente_id, :fecha_emision, :fecha_vencimiento, :total_estimado, :estado, :observaciones)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['leer'])) {
+    leer();
+}
+
+function leer() {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT * FROM presupuestos");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+}
+
+if (isset($_POST['id'])) {
+    id($_POST['id']);
+}
+
+function id($id) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT * FROM presupuestos WHERE id = $id");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+}
+
+if (isset($_POST['actualizar'])) {
+    actualizar($_POST['actualizar']);
+}
+
+function actualizar($lista) {
+    $json_datos = json_decode($lista, true);
+    $db = new DB();
+    $query = $db->conectar()->prepare("UPDATE presupuestos SET
+        cliente_id=:cliente_id,
+        fecha_emision=:fecha_emision,
+        fecha_vencimiento=:fecha_vencimiento,
+        total_estimado=:total_estimado,
+        estado=:estado,
+        observaciones=:observaciones
+        WHERE id=:id");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['eliminar'])) {
+    eliminar($_POST['eliminar']);
+}
+
+function eliminar($id) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("DELETE FROM presupuestos WHERE id = $id");
+    $query->execute();
+}
+
+?>

--- a/controladores/servicio_presupuesto_detalle.php
+++ b/controladores/servicio_presupuesto_detalle.php
@@ -1,0 +1,75 @@
+<?php
+
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    guardar($_POST['guardar']);
+}
+
+function guardar($lista) {
+    $json_datos = json_decode($lista, true);
+    $db = new DB();
+    $query = $db->conectar()->prepare("INSERT INTO detalle_presupuesto
+        (presupuesto_id, descripcion, cantidad, precio_unitario, subtotal)
+        VALUES (:presupuesto_id, :descripcion, :cantidad, :precio_unitario, :subtotal)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['leer'])) {
+    leer();
+}
+
+function leer() {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT * FROM detalle_presupuesto");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+}
+
+if (isset($_POST['id'])) {
+    id($_POST['id']);
+}
+
+function id($id) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT * FROM detalle_presupuesto WHERE id = $id");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+}
+
+if (isset($_POST['actualizar'])) {
+    actualizar($_POST['actualizar']);
+}
+
+function actualizar($lista) {
+    $json_datos = json_decode($lista, true);
+    $db = new DB();
+    $query = $db->conectar()->prepare("UPDATE detalle_presupuesto SET
+        presupuesto_id=:presupuesto_id,
+        descripcion=:descripcion,
+        cantidad=:cantidad,
+        precio_unitario=:precio_unitario,
+        subtotal=:subtotal
+        WHERE id=:id");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['eliminar'])) {
+    eliminar($_POST['eliminar']);
+}
+
+function eliminar($id) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("DELETE FROM detalle_presupuesto WHERE id = $id");
+    $query->execute();
+}
+
+?>


### PR DESCRIPTION
## Summary
- implement CRUD controller for service budgets
- add CRUD controller for service execution and their details
- extend SQL schema with budgets, services and related detail tables

## Testing
- `php -l controladores/servicio_presupuesto.php`
- `php -l controladores/servicio_presupuesto_detalle.php`
- `php -l controladores/servicio.php`
- `php -l controladores/servicio_detalle.php`


------
https://chatgpt.com/codex/tasks/task_e_689bf585989c8325baedabaeeb988155