### PR TITLE
feat: add service budget crud

### DIFF
--- a/main.php
+++ b/main.php
@@ -403,7 +403,7 @@
                                 <ul class="nav flex-column sub-menu">
 <!--                                    <li class="nav-item"><a class="nav-link" onclick="mostrarListarPedidoCompra(); return false;" href="#">Pedido</a></li>
                                     <li class="nav-item"><a class="nav-link" href="#" onclick="mostrarListarPresupuestoCompra(); return false;">Presupuesto</a></li>-->
-                                    <li class="nav-item"><a class="nav-link" href="#" onclick="; return false;">Presupuestos</a></li>
+                                    <li class="nav-item"><a class="nav-link" href="#" onclick="mostrarListarPresupuestoServicio(); return false;">Presupuestos</a></li>
                                     <li class="nav-item"><a class="nav-link" href="#" onclick="; return false;">Servicios</a></li>
 <!--                                    <li class="nav-item"><a class="nav-link" href="#" onclick="mostrarListarNotaCreditoCompra(); return false;">Nota de Credito</a></li>
                                     <li class="nav-item"><a class="nav-link" href="#" onclick="mostrarListarRemision(); return false;">Remision</a></li>

--- a/paginas/movimientos/servicio/presupuesto/agregar.jsp
+++ b/paginas/movimientos/servicio/presupuesto/agregar.jsp
@@ -140,7 +140,7 @@
         <hr> 
     </div>
     <div class="col-md-3">
-        <button class="btn btn-success form-control" onclick="guardarPresupuestoServicio(); return false;">Confirmar</button>
+        <button id="btn-confirmar-presu-serv" class="btn btn-success form-control" onclick="guardarPresupuestoServicio(); return false;">Confirmar</button>
     </div>
 
 </div>

--- a/paginas/movimientos/servicio/presupuesto/listar.jsp
+++ b/paginas/movimientos/servicio/presupuesto/listar.jsp
@@ -1,23 +1,29 @@
-
-
-<hr> 
-<div class="row" id="tabla-busqueda">
-    <div class="col-md-3">
-            <label >Desde</label>
+<div class="container-fluid card" style="padding: 30px;">
+    <div class="row">
+        <div class="col-md-10">
+            <h3>Lista Presupuesto Servicio</h3>
+        </div>
+        <div class="col-md-2">
+            <button class="btn btn-primary" onclick="mostrarAgregarPresupuestoServicio(); return false;"><i class="fa fa-plus"></i> Agregar</button>
+        </div>
+        <div class="col-md-12">
+            <hr>
+        </div>
+        <div class="col-md-3">
+            <label>Desde</label>
             <input type="date" id="desde" class="form-control">
         </div>
         <div class="col-md-3">
-            <label >Hasta</label>
+            <label>Hasta</label>
             <input type="date" id="hasta" class="form-control">
         </div>
         <div class="col-md-3">
-            <label >Operacion</label>
-            <button class="btn btn-primary form-control " onclick=" return false;">Buscar</button>
+            <label>Operacion</label>
+            <button class="btn btn-primary form-control" onclick="cargarTablaPresupuestoServicio(); return false;">Buscar</button>
         </div>
         <div class="col-md-12">
-            <hr> 
+            <hr>
         </div>
-    
         <div class="col-md-12">
             <table class="table table-bordered table-striped">
                 <thead>
@@ -32,6 +38,7 @@
                     </tr>
                 </thead>
                 <tbody id="presupuesto_listado_tb"></tbody>
-            </table> 
+            </table>
         </div>
+    </div>
 </div>

--- a/vista/presupuesto.js
+++ b/vista/presupuesto.js
@@ -121,6 +121,109 @@ $(document).on("keyup", ".costo-presu", function (evt) {
     $(this).closest("tr").find("td:eq(4)").text(formatearNumero(costo * cantidad));
     calcularTotalPresupuesto();
 });
+
+//------------------------------------------------------------------------------
+//------ PRESUPUESTO SERVICIO --------------------------------------------------
+//------------------------------------------------------------------------------
+function mostrarListarPresupuestoServicio() {
+    let contenido = dameContenido("paginas/movimientos/servicio/presupuesto/listar.jsp");
+    $(".contenido-principal").html(contenido);
+    cargarTablaPresupuestoServicio();
+}
+
+function mostrarAgregarPresupuestoServicio() {
+    let contenido = dameContenido("paginas/movimientos/servicio/presupuesto/agregar.jsp");
+    $(".contenido-principal").html(contenido);
+}
+
+function cargarTablaPresupuestoServicio() {
+    let datos = ejecutarAjax("controladores/servicio_presupuesto.php", "leer=1");
+    let tbody = $("#presupuesto_listado_tb");
+    tbody.html("");
+    if (datos !== "0") {
+        let json = JSON.parse(datos);
+        json.forEach((item) => {
+            tbody.append(`
+                <tr>
+                    <td>${item.id}</td>
+                    <td>${item.fecha_emision}</td>
+                    <td>${item.fecha_vencimiento}</td>
+                    <td>${item.cliente_id}</td>
+                    <td>N/A</td>
+                    <td>${item.estado}</td>
+                    <td>
+                        <button class="btn btn-primary btn-sm" onclick="editarPresupuestoServicio(${item.id}); return false;">Editar</button>
+                        <button class="btn btn-danger btn-sm" onclick="eliminarPresupuestoServicio(${item.id}); return false;">Eliminar</button>
+                    </td>
+                </tr>
+            `);
+        });
+    }
+}
+
+function guardarPresupuestoServicio() {
+    let lista = {
+        cliente_id: $("#id_cliente").val(),
+        fecha_emision: $("#fecha").val(),
+        fecha_vencimiento: $("#fecha_vencimiento").val(),
+        total_estimado: quitarDecimalesConvertir($("#total_presu_servicio").text()),
+        estado: "PENDIENTE",
+        observaciones: $("#observacion").val()
+    };
+
+    ejecutarAjax("controladores/servicio_presupuesto.php", "guardar=" + JSON.stringify(lista));
+    mensaje_dialogo_info("Registrado correctamente", "ATENCION");
+    mostrarListarPresupuestoServicio();
+}
+
+function editarPresupuestoServicio(id) {
+    let contenido = dameContenido("paginas/movimientos/servicio/presupuesto/agregar.jsp");
+    $(".contenido-principal").html(contenido);
+    let datos = ejecutarAjax("controladores/servicio_presupuesto.php", "id=" + id);
+    if (datos !== "0") {
+        let json = JSON.parse(datos);
+        $("#cod").val(json.id);
+        $("#fecha").val(json.fecha_emision);
+        $("#fecha_vencimiento").val(json.fecha_vencimiento);
+        $("#observacion").val(json.observaciones);
+        $("#total_presu_servicio").text(formatearNumero(json.total_estimado));
+        $("#btn-confirmar-presu-serv").text("Actualizar").attr("onclick", `actualizarPresupuestoServicio(${id}); return false;`);
+    }
+}
+
+function actualizarPresupuestoServicio(id) {
+    let lista = {
+        id: id,
+        cliente_id: $("#id_cliente").val(),
+        fecha_emision: $("#fecha").val(),
+        fecha_vencimiento: $("#fecha_vencimiento").val(),
+        total_estimado: quitarDecimalesConvertir($("#total_presu_servicio").text()),
+        estado: "PENDIENTE",
+        observaciones: $("#observacion").val()
+    };
+
+    ejecutarAjax("controladores/servicio_presupuesto.php", "actualizar=" + JSON.stringify(lista));
+    mensaje_dialogo_info("Actualizado correctamente", "ATENCION");
+    mostrarListarPresupuestoServicio();
+}
+
+function eliminarPresupuestoServicio(id) {
+    Swal.fire({
+        title: "ATENCION",
+        text: "Desea eliminar el registro?",
+        icon: "question",
+        showCancelButton: true,
+        confirmButtonColor: "#3085d6",
+        cancelButtonColor: "#d33",
+        cancelButtonText: "No",
+        confirmButtonText: "Si"
+    }).then((result) => {
+        if (result.isConfirmed) {
+            ejecutarAjax("controladores/servicio_presupuesto.php", "eliminar=" + id);
+            cargarTablaPresupuestoServicio();
+        }
+    });
+}
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expose Service Budget option in main menu
- implement service budget CRUD frontend handlers
- add service budget list page and tweak add page

## Testing
- `php -l main.php`
- `php -l controladores/servicio_presupuesto.php`


------
https://chatgpt.com/codex/tasks/task_e_689bfa823c3c83258c33dee21bc96979