### PR TITLE
Enable manual input for service forms

### DIFF
--- a/paginas/movimientos/servicio/diagnostico/agregar.jsp
+++ b/paginas/movimientos/servicio/diagnostico/agregar.jsp
@@ -22,12 +22,12 @@
     </div>
     <div class="col-md-3">
         <label>Sucursal</label>
-        <input type="text" class="form-control" id="sucursal" value="<%=sesion.nombre_sucur%>" readonly>
+        <input type="text" class="form-control" id="sucursal" placeholder="Ingrese sucursal">
     </div>
 
     <div class="col-md-3">
         <label>Usuario</label>
-        <input type="text" class="form-control" id="sucursal" value="<%=sesion.usuario_alias%>" readonly>
+        <input type="text" class="form-control" id="usuario" placeholder="Ingrese usuario">
     </div>
 
     <div class="col-md-3">
@@ -59,39 +59,11 @@
     </div>
     <div class="col-md-4">
         <label>Servicio</label>
-        <select  id="servicios_lst" class="form-control chosen-select">
-            <%
-                conexion cn = new conexion();
-                cn.conectar();
-                ResultSet rscli = cn.consultar("select * from servicios where UPPER(estado_servicios) = 'ACTIVO'");
-                while (rscli.next()) {
-            %>
-
-            <option  value="<%= rscli.getString("cod_tiposervicios")%>"><%= rscli.getString("tiposervicios")%></option>
-
-            <%
-                }  
-            %>
-
-        </select>
+        <input type="text" class="form-control" id="servicio" placeholder="Detalle del servicio">
     </div>
     <div class="col-md-4">
-        <label>Insumo</label>
-        <select  id="insumo_lst" class="form-control chosen-select">
-                   <%                   
-                cn.conectar();
-                ResultSet rs = cn.consultar("select * from insumos where UPPER(estado_insumos) = 'ACTIVO' order by cod_insumos");
-                while (rs.next()) {
-            %>
-
-            <option  value="<%= rs.getString("cod_insumos")%>"><%= rs.getString("descripcion")%></option>
-
-            <%
-                }
-
-            %>
-
-        </select>
+        <label>Repuesto</label>
+        <input type="text" class="form-control" id="repuesto" placeholder="Detalle del repuesto">
     </div>
 
 

--- a/paginas/movimientos/servicio/orden_servicio/agregar.jsp
+++ b/paginas/movimientos/servicio/orden_servicio/agregar.jsp
@@ -21,12 +21,12 @@
     </div>
     <div class="col-md-3">
         <label>Sucursal</label>
-        <input type="text" class="form-control" id="sucursal" value="<%=sesion.nombre_sucur%>" readonly>
+        <input type="text" class="form-control" id="sucursal" placeholder="Ingrese sucursal">
     </div>
 
     <div class="col-md-3">
         <label>Usuario</label>
-        <input type="text" class="form-control" id="sucursal" value="<%=sesion.usuario_alias%>" readonly>
+        <input type="text" class="form-control" id="usuario" placeholder="Ingrese usuario">
     </div>
 
     <div class="col-md-3">

--- a/paginas/movimientos/servicio/presupuesto/agregar.jsp
+++ b/paginas/movimientos/servicio/presupuesto/agregar.jsp
@@ -21,12 +21,12 @@
     </div>
     <div class="col-md-3">
         <label>Sucursal</label>
-        <input type="text" class="form-control" id="sucursal" value="<%=sesion.nombre_sucur%>" readonly>
+        <input type="text" class="form-control" id="sucursal" placeholder="Ingrese sucursal">
     </div>
 
     <div class="col-md-3">
         <label>Usuario</label>
-        <input type="text" class="form-control" id="sucursal" value="<%=sesion.usuario_alias%>" readonly>
+        <input type="text" class="form-control" id="usuario" placeholder="Ingrese usuario">
     </div>
 
     <div class="col-md-3">
@@ -42,7 +42,7 @@
 
     <div class="col-md-12">
         <label>Diagnostico</label>
-        <select  id="diagnostico_presu_lst" class="form-control"></select>
+        <input type="text" id="diagnostico" class="form-control" placeholder="Detalle del diagnostico">
     </div>
 
     <div class="col-md-12">

--- a/paginas/movimientos/servicio/recepcion/agregar.jsp
+++ b/paginas/movimientos/servicio/recepcion/agregar.jsp
@@ -24,17 +24,17 @@
 
     <div class="col-md-3">
         <label>Sucursal</label>
-        <input type="text" class="form-control" id="sucursal" value="<%=sesion.nombre_sucur%>" readonly>
+        <input type="text" class="form-control" id="sucursal" placeholder="Ingrese sucursal">
     </div>
 
     <div class="col-md-3">
         <label>Usuario</label>
-        <input type="text" class="form-control" id="sucursal" value="<%=sesion.usuario_alias%>" readonly>
+        <input type="text" class="form-control" id="usuario" placeholder="Ingrese usuario">
     </div>
 
 
     <div class="col-md-3">
-        <label>Fecha Emisión</label>
+        <label>Fecha EmisiÃ³n</label>
         <input type="date" class="form-control" id="fecha" readonly="" min="">
     </div>
 
@@ -73,10 +73,10 @@
                 <button class="form-control btn btn-primary">Agregar Equipo</button>
             </div>
             <div class="col-md-12">
-                <label>Tipo Contraseña</label>
+                <label>Tipo ContraseÃ±a</label>
                 <select  id="tipo_contra" class="form-control chosen-select">
-                    <option value="0">Selecciona un tipo de contraseña</option>
-                    <option value="SIN CONTRASEÑA">SIN CONTRASEÑA</option>
+                    <option value="0">Selecciona un tipo de contraseÃ±a</option>
+                    <option value="SIN CONTRASEÃ‘A">SIN CONTRASEÃ‘A</option>
                     <option value="PATRON">PATRON</option>
                     <option value="PIN">PIN</option>
                     <option value="ALFANUMERICO">ALFANUMERICO</option>
@@ -92,7 +92,7 @@
     </div>
 
     <div class="col-md-12">
-        <label>Descripción</label>
+        <label>DescripciÃ³n</label>
         <textarea  id="descripcion" class="form-control" cols="30" rows="5"></textarea>
     </div>
 
@@ -109,8 +109,8 @@
                 <tr>
                     <th>#</th>
                     <th>Equipo</th>
-                    <th>Tipo contraseña</th>
-                    <th>Contraseña</th>
+                    <th>Tipo contraseÃ±a</th>
+                    <th>ContraseÃ±a</th>
                     <th>Descripcion</th>
                     <th>Operaciones</th>
                 </tr>


### PR DESCRIPTION
## Summary
- Allow manual entry of branch and user data across service forms
- Replace service and spare part dropdowns with text fields in diagnostic form
- Let budgets accept free-form diagnostic input instead of DB-driven list

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689bfe20e4908325a5c85d4cc2855733