### PR TITLE
feat: add servicios CRUD

### DIFF
--- a/controladores/servicio.php
+++ b/controladores/servicio.php
@@ -1,0 +1,142 @@
+<?php
+require_once '../conexion/db.php';
+
+if(isset($_POST['guardar'])){
+    guardar($_POST['guardar']);
+}
+if(isset($_POST['leer'])){
+    leer();
+}
+if(isset($_POST['id'])){
+    id($_POST['id']);
+}
+if(isset($_POST['ultimo_registro'])){
+    ultimo_registro();
+}
+if(isset($_POST['actualizar'])){
+    actualizar($_POST['actualizar']);
+}
+if(isset($_POST['eliminar'])){
+    eliminar($_POST['eliminar']);
+}
+
+function guardar($lista){
+    $datos = json_decode($lista,true);
+    $db = new DB();
+    $pdo = $db->conectar();
+    try{
+        $pdo->beginTransaction();
+        $cab = $datos['cabecera'];
+        $stmt = $pdo->prepare("INSERT INTO servicios(id_cliente,id_equipo,fecha_servicio,estado,tecnico,observaciones,total,created_at) VALUES (?,?,?,?,?,?,?,NOW())");
+        $stmt->execute([
+            $cab['id_cliente'],
+            $cab['id_equipo'],
+            $cab['fecha_servicio'],
+            $cab['estado'],
+            $cab['tecnico'],
+            $cab['observaciones'],
+            $cab['total']
+        ]);
+        $id = $pdo->lastInsertId();
+        if(!empty($datos['detalles'])){
+            $stmtDet = $pdo->prepare("INSERT INTO servicio_detalles(id_servicio,descripcion,costo,estado,fecha_realizada) VALUES (?,?,?,?,?)");
+            foreach($datos['detalles'] as $d){
+                $stmtDet->execute([$id,$d['descripcion'],$d['costo'],$d['estado'],$d['fecha_realizada']]);
+            }
+        }
+        $pdo->commit();
+        echo $id;
+    }catch(Exception $e){
+        $pdo->rollBack();
+        echo "0";
+    }
+}
+
+function leer(){
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT s.id_servicio,s.fecha_servicio,c.nombre_cliente AS cliente,s.total,s.estado,e.cod_equipo AS equipo FROM servicios s JOIN cliente c ON c.cod_cliente=s.id_cliente JOIN equipo e ON e.cod_equipo=s.id_equipo");
+    $query->execute();
+    if($query->rowCount()){
+        echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
+    }else{
+        echo '0';
+    }
+}
+
+function id($id){
+    $db = new DB();
+    $pdo = $db->conectar();
+    $cab = $pdo->prepare("SELECT * FROM servicios WHERE id_servicio=?");
+    $cab->execute([$id]);
+    if(!$cab->rowCount()){
+        echo '0';
+        return;
+    }
+    $cabecera = $cab->fetch(PDO::FETCH_ASSOC);
+    $det = $pdo->prepare("SELECT * FROM servicio_detalles WHERE id_servicio=?");
+    $det->execute([$id]);
+    echo json_encode([
+        'cabecera'=>$cabecera,
+        'detalles'=>$det->fetchAll(PDO::FETCH_ASSOC)
+    ]);
+}
+
+function ultimo_registro(){
+    $db = new DB();
+    $query = $db->conectar()->prepare("SELECT id_servicio FROM servicios ORDER BY id_servicio DESC LIMIT 1");
+    $query->execute();
+    if($query->rowCount()){
+        echo json_encode($query->fetch(PDO::FETCH_ASSOC));
+    }else{
+        echo '0';
+    }
+}
+
+function actualizar($lista){
+    $datos = json_decode($lista,true);
+    $db = new DB();
+    $pdo = $db->conectar();
+    try{
+        $pdo->beginTransaction();
+        $cab = $datos['cabecera'];
+        $stmt = $pdo->prepare("UPDATE servicios SET id_cliente=?,id_equipo=?,fecha_servicio=?,estado=?,tecnico=?,observaciones=?,total=? WHERE id_servicio=?");
+        $stmt->execute([
+            $cab['id_cliente'],
+            $cab['id_equipo'],
+            $cab['fecha_servicio'],
+            $cab['estado'],
+            $cab['tecnico'],
+            $cab['observaciones'],
+            $cab['total'],
+            $cab['id_servicio']
+        ]);
+        $pdo->prepare("DELETE FROM servicio_detalles WHERE id_servicio=?")->execute([$cab['id_servicio']]);
+        if(!empty($datos['detalles'])){
+            $stmtDet = $pdo->prepare("INSERT INTO servicio_detalles(id_servicio,descripcion,costo,estado,fecha_realizada) VALUES (?,?,?,?,?)");
+            foreach($datos['detalles'] as $d){
+                $stmtDet->execute([$cab['id_servicio'],$d['descripcion'],$d['costo'],$d['estado'],$d['fecha_realizada']]);
+            }
+        }
+        $pdo->commit();
+        echo $cab['id_servicio'];
+    }catch(Exception $e){
+        $pdo->rollBack();
+        echo "0";
+    }
+}
+
+function eliminar($id){
+    $db = new DB();
+    $pdo = $db->conectar();
+    try{
+        $pdo->beginTransaction();
+        $pdo->prepare("DELETE FROM servicio_detalles WHERE id_servicio=?")->execute([$id]);
+        $pdo->prepare("DELETE FROM servicios WHERE id_servicio=?")->execute([$id]);
+        $pdo->commit();
+        echo '1';
+    }catch(Exception $e){
+        $pdo->rollBack();
+        echo '0';
+    }
+}
+?>

--- a/main.php
+++ b/main.php
@@ -626,6 +626,7 @@
         <script src="vista/marca.js"></script>
         <script src="vista/pedido.js"></script>
         <script src="vista/presupuesto.js"></script>
+        <script src="vista/servicio.js"></script>
         <script src="vista/orden_compra.js"></script>
         <script src="vista/factura_compra.js"></script>
         <script src="vista/nota_credito_compra.js"></script>

--- a/paginas/movimientos/servicio/servicios/agregar.php
+++ b/paginas/movimientos/servicio/servicios/agregar.php
@@ -1,0 +1,75 @@
+<div class="container-fluid card" style="padding: 30px;">
+<?php session_start(); ?>
+<div class="row">
+    <input type="text" id="editar" value="NO" hidden>
+    <div class="col-md-12">
+        <h3>Servicio Técnico</h3>
+    </div>
+    <div class="col-md-12"><hr></div>
+    <div class="col-md-2">
+        <label>Código</label>
+        <input type="text" id="id_servicio" class="form-control" readonly>
+    </div>
+    <div class="col-md-3">
+        <label>Fecha</label>
+        <input type="date" id="fecha_servicio" class="form-control">
+    </div>
+    <div class="col-md-3">
+        <label>Cliente</label>
+        <select id="cliente_lst" class="form-control"></select>
+    </div>
+    <div class="col-md-4">
+        <label>Equipo</label>
+        <select id="equipo_lst" class="form-control"></select>
+    </div>
+    <div class="col-md-3">
+        <label>Estado</label>
+        <select id="estado_servicio" class="form-control">
+            <option value="Pendiente">Pendiente</option>
+            <option value="En proceso">En proceso</option>
+            <option value="Terminado">Terminado</option>
+        </select>
+    </div>
+    <div class="col-md-3">
+        <label>Técnico</label>
+        <input type="text" id="tecnico" class="form-control">
+    </div>
+    <div class="col-md-12">
+        <label>Observaciones</label>
+        <textarea id="observaciones" class="form-control"></textarea>
+    </div>
+    <div class="col-md-12"><hr></div>
+    <div class="col-md-12"><h4>Detalles</h4></div>
+    <div class="col-md-4"><input type="text" id="desc_detalle" class="form-control" placeholder="Descripción"></div>
+    <div class="col-md-2"><input type="number" id="costo_detalle" class="form-control" placeholder="Costo"></div>
+    <div class="col-md-2">
+        <select id="estado_detalle" class="form-control">
+            <option value="Pendiente">Pendiente</option>
+            <option value="Realizado">Realizado</option>
+        </select>
+    </div>
+    <div class="col-md-2"><input type="date" id="fecha_detalle" class="form-control"></div>
+    <div class="col-md-2"><button class="btn btn-primary form-control" onclick="agregarDetalle(); return false;">Agregar</button></div>
+    <div class="col-md-12">
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Descripción</th>
+                    <th>Costo</th>
+                    <th>Estado</th>
+                    <th>Fecha realizada</th>
+                    <th>Opciones</th>
+                </tr>
+            </thead>
+            <tbody id="detalle_servicio"></tbody>
+        </table>
+    </div>
+    <div class="col-md-12"><hr></div>
+    <div class="col-md-3">
+        <button class="form-control btn btn-success" onclick="guardarServicio(); return false;"><i class="fa fa-save"></i> Guardar</button>
+    </div>
+    <div class="col-md-3">
+        <button class="form-control btn btn-danger" onclick="mostrarListarServicio(); return false;"><i class="fa fa-ban"></i> Cancelar</button>
+    </div>
+</div>
+</div>

--- a/paginas/movimientos/servicio/servicios/listar.php
+++ b/paginas/movimientos/servicio/servicios/listar.php
@@ -1,0 +1,27 @@
+<div class="container-fluid card" style="padding: 30px;">
+<div class="row">
+    <div class="col-md-10">
+        <h3>Lista de Servicios</h3>
+    </div>
+    <div class="col-md-2">
+        <button class="btn btn-primary" onclick="mostrarAgregarServicio(); return false;"><i class="fa fa-plus"></i>Agregar</button>
+    </div>
+    <div class="col-md-12"><hr></div>
+    <div class="col-md-12">
+        <table class="table table-bordered table-striped">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Fecha</th>
+                    <th>Cliente</th>
+                    <th>Equipo</th>
+                    <th>Total</th>
+                    <th>Estado</th>
+                    <th>Operaciones</th>
+                </tr>
+            </thead>
+            <tbody id="servicio_tb"></tbody>
+        </table>
+    </div>
+</div>
+</div>

--- a/vista/servicio.js
+++ b/vista/servicio.js
@@ -1,0 +1,157 @@
+function mostrarListarServicio(){
+    const contenido = dameContenido("paginas/movimientos/servicio/servicios/listar.php");
+    $(".contenido-principal").html(contenido);
+    cargarTablaServicio();
+}
+
+function cargarTablaServicio(){
+    const datos = ejecutarAjax("controladores/servicio.php","leer=1");
+    let filas = "";
+    if(datos !== "0"){
+        const json = JSON.parse(datos);
+        json.forEach(item=>{
+            filas += `<tr>
+                <td>${item.id_servicio}</td>
+                <td>${item.fecha_servicio}</td>
+                <td>${item.cliente}</td>
+                <td>${item.equipo}</td>
+                <td>${item.total}</td>
+                <td>${item.estado}</td>
+                <td>
+                    <button class='btn btn-sm btn-primary' onclick='editarServicio(${item.id_servicio}); return false;'>Editar</button>
+                    <button class='btn btn-sm btn-danger' onclick='eliminarServicio(${item.id_servicio}); return false;'>Eliminar</button>
+                </td>
+            </tr>`;
+        });
+    }
+    $("#servicio_tb").html(filas);
+}
+
+function mostrarAgregarServicio(){
+    const contenido = dameContenido("paginas/movimientos/servicio/servicios/agregar.php");
+    $(".contenido-principal").html(contenido);
+    cargarListaCliente("#cliente_lst");
+    cargarListaEquipo("#equipo_lst");
+    const ultimo = ejecutarAjax("controladores/servicio.php","ultimo_registro=1");
+    if(ultimo === "0"){
+        $("#id_servicio").val("1");
+    }else{
+        const json = JSON.parse(ultimo);
+        $("#id_servicio").val(quitarDecimalesConvertir(json.id_servicio)+1);
+    }
+    dameFechaActual("fecha_servicio");
+}
+
+function agregarDetalle(){
+    const desc = $("#desc_detalle").val().trim();
+    const costo = quitarDecimalesConvertir($("#costo_detalle").val());
+    const estado = $("#estado_detalle").val();
+    const fecha = $("#fecha_detalle").val();
+    if(desc.length===0 || costo<=0){return;}
+    $("#detalle_servicio").append(`
+        <tr>
+            <td>${desc}</td>
+            <td>${costo}</td>
+            <td>${estado}</td>
+            <td>${fecha}</td>
+            <td><button class='btn btn-danger btn-sm quitar-detalle'>Quitar</button></td>
+        </tr>`);
+    $("#desc_detalle,#costo_detalle,#fecha_detalle").val("");
+}
+
+$(document).on("click",".quitar-detalle",function(){
+    $(this).closest("tr").remove();
+});
+
+function guardarServicio(){
+    if($("#cliente_lst").val()==="0" || $("#equipo_lst").val()==="0"){
+        mensaje_dialogo_info_ERROR("Debes seleccionar cliente y equipo","ATENCION");
+        return;
+    }
+    let cab = {
+        id_cliente: $("#cliente_lst").val(),
+        id_equipo: $("#equipo_lst").val(),
+        fecha_servicio: $("#fecha_servicio").val(),
+        estado: $("#estado_servicio").val(),
+        tecnico: $("#tecnico").val(),
+        observaciones: $("#observaciones").val(),
+        total: 0
+    };
+    let detalles = [];
+    $("#detalle_servicio tr").each(function(){
+        let tds = $(this).find("td");
+        detalles.push({
+            descripcion: tds.eq(0).text(),
+            costo: tds.eq(1).text(),
+            estado: tds.eq(2).text(),
+            fecha_realizada: tds.eq(3).text()
+        });
+        cab.total += quitarDecimalesConvertir(tds.eq(1).text());
+    });
+    let payload = {cabecera:cab,detalles:detalles};
+    let resp = "";
+    if($("#editar").val()==="NO"){
+        resp = ejecutarAjax("controladores/servicio.php","guardar="+JSON.stringify(payload));
+    }else{
+        payload.cabecera.id_servicio = $("#id_servicio").val();
+        resp = ejecutarAjax("controladores/servicio.php","actualizar="+JSON.stringify(payload));
+    }
+    if(resp !== "0"){
+        mensaje_dialogo_info("Registro guardado","EXITO");
+        mostrarListarServicio();
+    }else{
+        mensaje_dialogo_info_ERROR("No se pudo guardar","ATENCION");
+    }
+}
+
+function editarServicio(id){
+    const contenido = dameContenido("paginas/movimientos/servicio/servicios/agregar.php");
+    $(".contenido-principal").html(contenido);
+    $("#editar").val("SI");
+    cargarListaCliente("#cliente_lst");
+    cargarListaEquipo("#equipo_lst");
+    const datos = ejecutarAjax("controladores/servicio.php","id="+id);
+    if(datos === "0") return;
+    const json = JSON.parse(datos);
+    const cab = json.cabecera;
+    $("#id_servicio").val(cab.id_servicio);
+    $("#fecha_servicio").val(cab.fecha_servicio);
+    setTimeout(()=>{
+        $("#cliente_lst").val(cab.id_cliente);
+        $("#equipo_lst").val(cab.id_equipo);
+    },300);
+    $("#estado_servicio").val(cab.estado);
+    $("#tecnico").val(cab.tecnico);
+    $("#observaciones").val(cab.observaciones);
+    json.detalles.forEach(d=>{
+        $("#detalle_servicio").append(`<tr><td>${d.descripcion}</td><td>${d.costo}</td><td>${d.estado}</td><td>${d.fecha_realizada}</td><td><button class='btn btn-danger btn-sm quitar-detalle'>Quitar</button></td></tr>`);
+    });
+}
+
+function eliminarServicio(id){
+    Swal.fire({
+        title:"ATENCION",
+        text:"Desea eliminar el registro?",
+        icon:"question",
+        showCancelButton:true,
+        confirmButtonText:"Si",
+        cancelButtonText:"No"
+    }).then(res=>{
+        if(res.isConfirmed){
+            const r = ejecutarAjax("controladores/servicio.php","eliminar="+id);
+            if(r !== "0"){cargarTablaServicio();}
+        }
+    });
+}
+
+function cargarListaEquipo(componente){
+    const datos = ejecutarAjax("controladores/equipo.php","leer=1");
+    let option = "<option value='0'>Selecciona un equipo</option>";
+    if(datos !== "0"){
+        const json = JSON.parse(datos);
+        json.forEach(item=>{
+            option += `<option value='${item.cod_equipo}'>${item.cod_equipo}</option>`;
+        });
+    }
+    $(componente).html(option);
+}


### PR DESCRIPTION
## Summary
- add controller for servicios with cabecera-detalle CRUD
- create pages and scripts for managing services
- include servicio.js in main layout

## Testing
- `php -l controladores/servicio.php`
- `php -l paginas/movimientos/servicio/servicios/agregar.php`
- `php -l paginas/movimientos/servicio/servicios/listar.php`


------
https://chatgpt.com/codex/tasks/task_e_689c0ca5048883258eed8127f423313b