### PR TITLE
feat: add service CRUD with header-detail

### DIFF
--- a/controladores/servicio.php
+++ b/controladores/servicio.php
@@ -27,10 +27,12 @@ function guardar($lista){
     try{
         $pdo->beginTransaction();
         $cab = $datos['cabecera'];
-        $stmt = $pdo->prepare("INSERT INTO servicios(id_cliente,id_equipo,fecha_servicio,estado,tecnico,observaciones,total,created_at) VALUES (?,?,?,?,?,?,?,NOW())");
+        $stmt = $pdo->prepare("INSERT INTO servicios(id_cliente,ci_cliente,telefono_cliente,email_cliente,fecha_servicio,estado,tecnico,observaciones,total,created_at) VALUES (?,?,?,?,?,?,?,?,?,NOW())");
         $stmt->execute([
             $cab['id_cliente'],
-            $cab['id_equipo'],
+            $cab['ci_cliente'],
+            $cab['telefono_cliente'],
+            $cab['email_cliente'],
             $cab['fecha_servicio'],
             $cab['estado'],
             $cab['tecnico'],
@@ -39,9 +41,9 @@ function guardar($lista){
         ]);
         $id = $pdo->lastInsertId();
         if(!empty($datos['detalles'])){
-            $stmtDet = $pdo->prepare("INSERT INTO servicio_detalles(id_servicio,descripcion,costo,estado,fecha_realizada) VALUES (?,?,?,?,?)");
+            $stmtDet = $pdo->prepare("INSERT INTO servicio_detalles(id_servicio,tipo_servicio,descripcion,producto_relacionado,cantidad,precio_unitario,subtotal,observaciones) VALUES (?,?,?,?,?,?,?,?)");
             foreach($datos['detalles'] as $d){
-                $stmtDet->execute([$id,$d['descripcion'],$d['costo'],$d['estado'],$d['fecha_realizada']]);
+                $stmtDet->execute([$id,$d['tipo_servicio'],$d['descripcion'],$d['producto_relacionado'],$d['cantidad'],$d['precio_unitario'],$d['subtotal'],$d['observaciones']]);
             }
         }
         $pdo->commit();
@@ -54,7 +56,7 @@ function guardar($lista){
 
 function leer(){
     $db = new DB();
-    $query = $db->conectar()->prepare("SELECT s.id_servicio,s.fecha_servicio,c.nombre_cliente AS cliente,s.total,s.estado,e.cod_equipo AS equipo FROM servicios s JOIN cliente c ON c.cod_cliente=s.id_cliente JOIN equipo e ON e.cod_equipo=s.id_equipo");
+    $query = $db->conectar()->prepare("SELECT s.id_servicio,s.fecha_servicio,c.nombre_cliente AS cliente,s.total,s.estado FROM servicios s JOIN cliente c ON c.cod_cliente=s.id_cliente");
     $query->execute();
     if($query->rowCount()){
         echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
@@ -99,10 +101,12 @@ function actualizar($lista){
     try{
         $pdo->beginTransaction();
         $cab = $datos['cabecera'];
-        $stmt = $pdo->prepare("UPDATE servicios SET id_cliente=?,id_equipo=?,fecha_servicio=?,estado=?,tecnico=?,observaciones=?,total=? WHERE id_servicio=?");
+        $stmt = $pdo->prepare("UPDATE servicios SET id_cliente=?,ci_cliente=?,telefono_cliente=?,email_cliente=?,fecha_servicio=?,estado=?,tecnico=?,observaciones=?,total=? WHERE id_servicio=?");
         $stmt->execute([
             $cab['id_cliente'],
-            $cab['id_equipo'],
+            $cab['ci_cliente'],
+            $cab['telefono_cliente'],
+            $cab['email_cliente'],
             $cab['fecha_servicio'],
             $cab['estado'],
             $cab['tecnico'],
@@ -112,9 +116,9 @@ function actualizar($lista){
         ]);
         $pdo->prepare("DELETE FROM servicio_detalles WHERE id_servicio=?")->execute([$cab['id_servicio']]);
         if(!empty($datos['detalles'])){
-            $stmtDet = $pdo->prepare("INSERT INTO servicio_detalles(id_servicio,descripcion,costo,estado,fecha_realizada) VALUES (?,?,?,?,?)");
+            $stmtDet = $pdo->prepare("INSERT INTO servicio_detalles(id_servicio,tipo_servicio,descripcion,producto_relacionado,cantidad,precio_unitario,subtotal,observaciones) VALUES (?,?,?,?,?,?,?,?)");
             foreach($datos['detalles'] as $d){
-                $stmtDet->execute([$cab['id_servicio'],$d['descripcion'],$d['costo'],$d['estado'],$d['fecha_realizada']]);
+                $stmtDet->execute([$cab['id_servicio'],$d['tipo_servicio'],$d['descripcion'],$d['producto_relacionado'],$d['cantidad'],$d['precio_unitario'],$d['subtotal'],$d['observaciones']]);
             }
         }
         $pdo->commit();

--- a/paginas/movimientos/servicio/servicios/agregar.php
+++ b/paginas/movimientos/servicio/servicios/agregar.php
@@ -3,7 +3,7 @@
 <div class="row">
     <input type="text" id="editar" value="NO" hidden>
     <div class="col-md-12">
-        <h3>Servicio Técnico</h3>
+        <h3>Registro de Servicios</h3>
     </div>
     <div class="col-md-12"><hr></div>
     <div class="col-md-2">
@@ -18,46 +18,57 @@
         <label>Cliente</label>
         <select id="cliente_lst" class="form-control"></select>
     </div>
-    <div class="col-md-4">
-        <label>Equipo</label>
-        <select id="equipo_lst" class="form-control"></select>
+    <div class="col-md-2">
+        <label>CI Cliente</label>
+        <input type="text" id="ci_cliente" class="form-control" readonly>
+    </div>
+    <div class="col-md-2">
+        <label>Teléfono</label>
+        <input type="text" id="telefono_cliente" class="form-control" readonly>
     </div>
     <div class="col-md-3">
-        <label>Estado</label>
-        <select id="estado_servicio" class="form-control">
-            <option value="Pendiente">Pendiente</option>
-            <option value="En proceso">En proceso</option>
-            <option value="Terminado">Terminado</option>
-        </select>
+        <label>Email</label>
+        <input type="email" id="email_cliente" class="form-control" readonly>
     </div>
     <div class="col-md-3">
-        <label>Técnico</label>
+        <label>Técnico Asignado</label>
         <input type="text" id="tecnico" class="form-control">
     </div>
+    <div class="col-md-3">
+        <label>Estado del Servicio</label>
+        <select id="estado_servicio" class="form-control">
+            <option value="Pendiente">Pendiente</option>
+            <option value="En Proceso">En Proceso</option>
+            <option value="Completado">Completado</option>
+            <option value="Cancelado">Cancelado</option>
+        </select>
+    </div>
     <div class="col-md-12">
-        <label>Observaciones</label>
+        <label>Observaciones Generales</label>
         <textarea id="observaciones" class="form-control"></textarea>
     </div>
     <div class="col-md-12"><hr></div>
-    <div class="col-md-12"><h4>Detalles</h4></div>
-    <div class="col-md-4"><input type="text" id="desc_detalle" class="form-control" placeholder="Descripción"></div>
-    <div class="col-md-2"><input type="number" id="costo_detalle" class="form-control" placeholder="Costo"></div>
-    <div class="col-md-2">
-        <select id="estado_detalle" class="form-control">
-            <option value="Pendiente">Pendiente</option>
-            <option value="Realizado">Realizado</option>
-        </select>
+    <div class="col-md-12"><h4>Detalle de Servicios</h4></div>
+    <div class="col-md-3"><input type="text" id="tipo_servicio" class="form-control" placeholder="Tipo de Servicio"></div>
+    <div class="col-md-3"><input type="text" id="desc_servicio" class="form-control" placeholder="Descripción"></div>
+    <div class="col-md-2"><input type="text" id="producto_rel" class="form-control" placeholder="Producto Relacionado"></div>
+    <div class="col-md-1"><input type="number" id="cant_servicio" class="form-control" value="1" min="1" placeholder="Cant."></div>
+    <div class="col-md-2"><input type="number" id="precio_servicio" class="form-control" placeholder="Precio Unitario"></div>
+    <div class="col-md-1"><input type="text" id="obs_detalle" class="form-control" placeholder="Obs."></div>
+    <div class="col-md-12" style="margin-top:10px;">
+        <button class="btn btn-primary" onclick="agregarDetalle(); return false;">Agregar</button>
     </div>
-    <div class="col-md-2"><input type="date" id="fecha_detalle" class="form-control"></div>
-    <div class="col-md-2"><button class="btn btn-primary form-control" onclick="agregarDetalle(); return false;">Agregar</button></div>
-    <div class="col-md-12">
+    <div class="col-md-12" style="margin-top:10px;">
         <table class="table table-bordered">
             <thead>
                 <tr>
+                    <th>Tipo</th>
                     <th>Descripción</th>
-                    <th>Costo</th>
-                    <th>Estado</th>
-                    <th>Fecha realizada</th>
+                    <th>Producto</th>
+                    <th>Cantidad</th>
+                    <th>Precio Unitario</th>
+                    <th>Subtotal</th>
+                    <th>Observaciones</th>
                     <th>Opciones</th>
                 </tr>
             </thead>

--- a/paginas/movimientos/servicio/servicios/listar.php
+++ b/paginas/movimientos/servicio/servicios/listar.php
@@ -14,7 +14,6 @@
                     <th>#</th>
                     <th>Fecha</th>
                     <th>Cliente</th>
-                    <th>Equipo</th>
                     <th>Total</th>
                     <th>Estado</th>
                     <th>Operaciones</th>

--- a/servicios.sql
+++ b/servicios.sql
@@ -2,10 +2,12 @@
 CREATE TABLE `servicios` (
   `id_servicio` INT NOT NULL AUTO_INCREMENT,
   `id_cliente` INT NOT NULL,
-  `id_equipo` INT NOT NULL,
+  `ci_cliente` VARCHAR(20),
+  `telefono_cliente` VARCHAR(20),
+  `email_cliente` VARCHAR(100),
   `fecha_servicio` DATE NOT NULL,
-  `estado` VARCHAR(20) NOT NULL,
   `tecnico` VARCHAR(100) NOT NULL,
+  `estado` VARCHAR(20) NOT NULL,
   `observaciones` TEXT,
   `total` DECIMAL(10,2),
   `created_at` DATETIME,
@@ -14,13 +16,16 @@ CREATE TABLE `servicios` (
 
 -- Tabla: servicio_detalles
 CREATE TABLE `servicio_detalles` (
-  `id` INT NOT NULL AUTO_INCREMENT,
+  `id_servicio_detalle` INT NOT NULL AUTO_INCREMENT,
   `id_servicio` INT NOT NULL,
+  `tipo_servicio` VARCHAR(100),
   `descripcion` TEXT,
-  `costo` DECIMAL(10,2),
-  `estado` VARCHAR(20),
-  `fecha_realizada` DATE,
-  PRIMARY KEY (`id`),
+  `producto_relacionado` VARCHAR(100),
+  `cantidad` INT,
+  `precio_unitario` DECIMAL(10,2),
+  `subtotal` DECIMAL(10,2),
+  `observaciones` TEXT,
+  PRIMARY KEY (`id_servicio_detalle`),
   CONSTRAINT `servicio_detalles_servicio_fk` FOREIGN KEY (`id_servicio`) REFERENCES `servicios` (`id_servicio`) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
## Summary
- implement service registration form with client contact fields and detail items
- persist service and detail records
- update listing and SQL schema

## Testing
- `php -l controladores/servicio.php`
- `php -l paginas/movimientos/servicio/servicios/agregar.php`
- `php -l paginas/movimientos/servicio/servicios/listar.php`


------
https://chatgpt.com/codex/tasks/task_e_689d50f55eec8325a5f75f14059cbb88