### PR TITLE
Remove email field and add product selector to services

### DIFF
--- a/controladores/servicio.php
+++ b/controladores/servicio.php
@@ -27,12 +27,11 @@ function guardar($lista){
     try{
         $pdo->beginTransaction();
         $cab = $datos['cabecera'];
-        $stmt = $pdo->prepare("INSERT INTO servicios(id_cliente,ci_cliente,telefono_cliente,email_cliente,fecha_servicio,estado,tecnico,observaciones,total,created_at) VALUES (?,?,?,?,?,?,?,?,?,NOW())");
+        $stmt = $pdo->prepare("INSERT INTO servicios(id_cliente,ci_cliente,telefono_cliente,fecha_servicio,estado,tecnico,observaciones,total,created_at) VALUES (?,?,?,?,?,?,?,?,NOW())");
         $stmt->execute([
             $cab['id_cliente'],
             $cab['ci_cliente'],
             $cab['telefono_cliente'],
-            $cab['email_cliente'],
             $cab['fecha_servicio'],
             $cab['estado'],
             $cab['tecnico'],
@@ -101,12 +100,11 @@ function actualizar($lista){
     try{
         $pdo->beginTransaction();
         $cab = $datos['cabecera'];
-        $stmt = $pdo->prepare("UPDATE servicios SET id_cliente=?,ci_cliente=?,telefono_cliente=?,email_cliente=?,fecha_servicio=?,estado=?,tecnico=?,observaciones=?,total=? WHERE id_servicio=?");
+        $stmt = $pdo->prepare("UPDATE servicios SET id_cliente=?,ci_cliente=?,telefono_cliente=?,fecha_servicio=?,estado=?,tecnico=?,observaciones=?,total=? WHERE id_servicio=?");
         $stmt->execute([
             $cab['id_cliente'],
             $cab['ci_cliente'],
             $cab['telefono_cliente'],
-            $cab['email_cliente'],
             $cab['fecha_servicio'],
             $cab['estado'],
             $cab['tecnico'],

--- a/paginas/movimientos/servicio/servicios/agregar.php
+++ b/paginas/movimientos/servicio/servicios/agregar.php
@@ -22,13 +22,9 @@
         <label>CI Cliente</label>
         <input type="text" id="ci_cliente" class="form-control" readonly>
     </div>
-    <div class="col-md-2">
+    <div class="col-md-3">
         <label>Teléfono</label>
         <input type="text" id="telefono_cliente" class="form-control" readonly>
-    </div>
-    <div class="col-md-3">
-        <label>Email</label>
-        <input type="email" id="email_cliente" class="form-control" readonly>
     </div>
     <div class="col-md-3">
         <label>Técnico Asignado</label>
@@ -51,7 +47,7 @@
     <div class="col-md-12"><h4>Detalle de Servicios</h4></div>
     <div class="col-md-3"><input type="text" id="tipo_servicio" class="form-control" placeholder="Tipo de Servicio"></div>
     <div class="col-md-3"><input type="text" id="desc_servicio" class="form-control" placeholder="Descripción"></div>
-    <div class="col-md-2"><input type="text" id="producto_rel" class="form-control" placeholder="Producto Relacionado"></div>
+    <div class="col-md-2"><select id="producto_rel" class="form-control"></select></div>
     <div class="col-md-1"><input type="number" id="cant_servicio" class="form-control" value="1" min="1" placeholder="Cant."></div>
     <div class="col-md-2"><input type="number" id="precio_servicio" class="form-control" placeholder="Precio"></div>
     <div class="col-md-1"><input type="text" id="obs_detalle" class="form-control" placeholder="Obs."></div>

--- a/servicios.sql
+++ b/servicios.sql
@@ -4,7 +4,6 @@ CREATE TABLE `servicios` (
   `id_cliente` INT NOT NULL,
   `ci_cliente` VARCHAR(20),
   `telefono_cliente` VARCHAR(20),
-  `email_cliente` VARCHAR(100),
   `fecha_servicio` DATE NOT NULL,
   `tecnico` VARCHAR(100) NOT NULL,
   `estado` VARCHAR(20) NOT NULL,

--- a/vista/servicio.js
+++ b/vista/servicio.js
@@ -30,6 +30,7 @@ function mostrarAgregarServicio(){
     const contenido = dameContenido("paginas/movimientos/servicio/servicios/agregar.php");
     $(".contenido-principal").html(contenido);
     cargarListaCliente("#cliente_lst");
+    cargarListaProducto("#producto_rel");
     const ultimo = ejecutarAjax("controladores/servicio.php","ultimo_registro=1");
     if(ultimo === "0"){
         $("#id_servicio").val("1");
@@ -40,16 +41,17 @@ function mostrarAgregarServicio(){
     dameFechaActual("fecha_servicio");
     $(document).off('change','#cliente_lst').on('change','#cliente_lst',function(){
         const id = $(this).val();
-        if(id==="0"){ $("#ci_cliente,#telefono_cliente,#email_cliente").val(""); return; }
+        if(id==="0"){ $("#ci_cliente,#telefono_cliente").val(""); return; }
         const datos = ejecutarAjax("controladores/cliente.php","id="+id);
-        if(datos!=="0"){ const c = JSON.parse(datos); $("#ci_cliente").val(c.ci_cliente||""); $("#telefono_cliente").val(c.telefono||""); $("#email_cliente").val(c.email_cliente||""); }
+        if(datos!=="0"){ const c = JSON.parse(datos); $("#ci_cliente").val(c.ci_cliente||""); $("#telefono_cliente").val(c.telefono||""); }
     });
 }
 
 function agregarDetalle(){
     const tipo = $("#tipo_servicio").val().trim();
     const desc = $("#desc_servicio").val().trim();
-    const prod = $("#producto_rel").val().trim();
+    const prodVal = $("#producto_rel").val();
+    const prod = prodVal === "0" ? "" : $("#producto_rel option:selected").text();
     const cant = quitarDecimalesConvertir($("#cant_servicio").val());
     const precio = quitarDecimalesConvertir($("#precio_servicio").val());
     const obs = $("#obs_detalle").val().trim();
@@ -66,7 +68,8 @@ function agregarDetalle(){
             <td>${obs}</td>
             <td><button class='btn btn-danger btn-sm quitar-detalle'>Quitar</button></td>
         </tr>`);
-    $("#tipo_servicio,#desc_servicio,#producto_rel,#cant_servicio,#precio_servicio,#obs_detalle").val("");
+    $("#tipo_servicio,#desc_servicio,#cant_servicio,#precio_servicio,#obs_detalle").val("");
+    $("#producto_rel").val("0");
     $("#cant_servicio").val(1);
 }
 
@@ -83,7 +86,6 @@ function guardarServicio(){
         id_cliente: $("#cliente_lst").val(),
         ci_cliente: $("#ci_cliente").val(),
         telefono_cliente: $("#telefono_cliente").val(),
-        email_cliente: $("#email_cliente").val(),
         fecha_servicio: $("#fecha_servicio").val(),
         estado: $("#estado_servicio").val(),
         tecnico: $("#tecnico").val(),
@@ -125,6 +127,7 @@ function editarServicio(id){
     $(".contenido-principal").html(contenido);
     $("#editar").val("SI");
     cargarListaCliente("#cliente_lst");
+    cargarListaProducto("#producto_rel");
     const datos = ejecutarAjax("controladores/servicio.php","id="+id);
     if(datos === "0") return;
     const json = JSON.parse(datos);
@@ -136,7 +139,6 @@ function editarServicio(id){
     },300);
     $("#ci_cliente").val(cab.ci_cliente);
     $("#telefono_cliente").val(cab.telefono_cliente);
-    $("#email_cliente").val(cab.email_cliente);
     $("#estado_servicio").val(cab.estado);
     $("#tecnico").val(cab.tecnico);
     $("#observaciones").val(cab.observaciones);


### PR DESCRIPTION
## Summary
- drop email from service registration and model
- allow selecting related products from the product catalog

## Testing
- `php -l paginas/movimientos/servicio/servicios/agregar.php`
- `php -l controladores/servicio.php`
- `node --check vista/servicio.js`


------
https://chatgpt.com/codex/tasks/task_e_689d576ad43c83258a58f800ed17ea0d