### PR TITLE
Validar duplicados y filtrar ordenes de compra por estado

### DIFF
--- a/paginas/movimientos/compra/orden_compra/listar.php
+++ b/paginas/movimientos/compra/orden_compra/listar.php
@@ -38,7 +38,7 @@
           <select id="estado_lst_oc" class="form-control">
             <option value="">Todos</option>
             <option value="PENDIENTE">Pendiente</option>
-            <option value="APROBADO">Aprobado</option>
+            <option value="UTILIZADO">Utilizado</option>
             <option value="ANULADO">Anulado</option>
           </select>
           <small class="text-muted">Filtro opcional por estado</small>

--- a/vista/orden_compra.js
+++ b/vista/orden_compra.js
@@ -271,6 +271,7 @@ function cargarTablaOrdenCompra() {
 
   const desde = $("#fecha_desde_oc").val();
   const hasta = $("#fecha_hasta_oc").val();
+  const estado = $("#estado_lst_oc").val();
 
   if (desde && hasta && desde > hasta) {
     mensaje_dialogo_info_ERROR("La fecha desde no puede ser mayor a la hasta", "ATENCION");
@@ -281,6 +282,7 @@ function cargarTablaOrdenCompra() {
   params.append("leer", 1);
   if (desde) params.append("desde", desde);
   if (hasta) params.append("hasta", hasta);
+  if (estado) params.append("estado", estado);
 
   const raw = ejecutarAjax("controladores/orden_compra.php", params.toString());
   console.log("OC leer =>", raw);
@@ -326,6 +328,7 @@ $(document).on("keyup", "#b_cliente2", function () {
   const q = $("#b_cliente2").val().trim();
   const desde = $("#fecha_desde_oc").val();
   const hasta = $("#fecha_hasta_oc").val();
+  const estado = $("#estado_lst_oc").val();
 
   if (desde && hasta && desde > hasta) {
     mensaje_dialogo_info_ERROR("La fecha desde no puede ser mayor a la hasta", "ATENCION");
@@ -336,6 +339,7 @@ $(document).on("keyup", "#b_cliente2", function () {
   params.append("leer_buscar", q);
   if (desde) params.append("desde", desde);
   if (hasta) params.append("hasta", hasta);
+  if (estado) params.append("estado", estado);
 
   const raw = ejecutarAjax("controladores/orden_compra.php", params.toString());
   console.log("OC buscar =>", raw);
@@ -386,6 +390,15 @@ $(document).on("change", "#fecha_desde_oc, #fecha_hasta_oc", function(){
   }
 });
 
+$(document).on("change", "#estado_lst_oc", function(){
+  const q = $("#b_cliente2").val().trim();
+  if (q){
+    $("#b_cliente2").trigger("keyup");
+  } else {
+    cargarTablaOrdenCompra();
+  }
+});
+
 /* ===================== Otros eventos ===================== */
 function imprimirOrdenCompra(id) {
   window.open("paginas/movimientos/compra/orden_compra/print.php?id=" + id);
@@ -418,7 +431,9 @@ $(document).on("change", "#presupuesto_compra_lst", function () {
     } else {
       const json_data = parseJSONSafe(data) || [];
       $("#orden_compra_compra").html("");
+      let omitidos = 0;
       json_data.forEach(item=>{
+        if (productoYaEnTabla(item.cod_material)) { omitidos++; return; }
         const costo = quitarDecimalesConvertir(item.costo);
         const cant  = quitarDecimalesConvertir(item.cantidad);
         $("#orden_compra_compra").append(`
@@ -434,6 +449,9 @@ $(document).on("change", "#presupuesto_compra_lst", function () {
           </tr>
         `);
       });
+      if (omitidos > 0){
+        mensaje_dialogo_info_ERROR(`Se omitieron ${omitidos} productos repetidos`, "ATENCION");
+      }
     }
   }
   calcularTotalOrdenCompra();


### PR DESCRIPTION
## Summary
- Evitar productos repetidos al cargar presupuestos y validar duplicados en backend
- Agregar filtro de estado (UTILIZADO, PENDIENTE, ANULADO) en listado de órdenes de compra
- Permitir filtrar por estado en controladores y vista

## Testing
- `php -l controladores/orden_compra.php`
- `node --check vista/orden_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_689d58a685a88325850999552c26df1c