### PR TITLE
feat: filter sales invoices by date

### DIFF
--- a/controladores/factura.php
+++ b/controladores/factura.php
@@ -192,6 +192,22 @@ if (isset($_REQUEST['leer'])) {
     $params[':estado'] = $_REQUEST['estado'];
   }
 
+  // Filtro por rango de fechas (opcional)
+  if (isset($_REQUEST['desde']) && $_REQUEST['desde'] !== '') {
+    $dt = DateTime::createFromFormat('Y-m-d', $_REQUEST['desde']);
+    if ($dt) {
+      $where .= " AND f.fecha_emision >= :desde";
+      $params[':desde'] = $dt->format('Y-m-d');
+    }
+  }
+  if (isset($_REQUEST['hasta']) && $_REQUEST['hasta'] !== '') {
+    $dt = DateTime::createFromFormat('Y-m-d', $_REQUEST['hasta']);
+    if ($dt) {
+      $where .= " AND f.fecha_emision <= :hasta";
+      $params[':hasta'] = $dt->format('Y-m-d');
+    }
+  }
+
   // Búsqueda (nombre cliente, nro, nro completo)
   if (isset($_REQUEST['buscar']) && $_REQUEST['buscar'] !== '') {
     $b = '%'.$_REQUEST['buscar'].'%';

--- a/paginas/movimientos/venta/factura_venta/listar.php
+++ b/paginas/movimientos/venta/factura_venta/listar.php
@@ -11,11 +11,19 @@
   <div class="card shadow rounded-4 border-0">
     <div class="card-body">
       <div class="row g-3 align-items-end mb-3">
-        <div class="col-md-7">
+        <div class="col-md-4">
           <label for="b_factura" class="form-label fw-semibold">Buscar</label>
           <input type="text" id="b_factura" class="form-control form-control-lg" placeholder="Cliente, Nro, 001-001-0000001...">
         </div>
-        <div class="col-md-3">
+        <div class="col-md-2">
+          <label for="desde_txt" class="form-label fw-semibold">Desde</label>
+          <input type="date" id="desde_txt" class="form-control form-control-lg">
+        </div>
+        <div class="col-md-2">
+          <label for="hasta_txt" class="form-label fw-semibold">Hasta</label>
+          <input type="date" id="hasta_txt" class="form-control form-control-lg">
+        </div>
+        <div class="col-md-2">
           <label for="estado_lst" class="form-label fw-semibold">Estado</label>
           <select id="estado_lst" class="form-select form-select-lg">
             <option value="">Todos</option>
@@ -24,7 +32,7 @@
           </select>
         </div>
         <div class="col-md-2 d-grid">
-          <button class="btn btn-primary btn-lg" onclick="cargarTablaFacturas(); return false;">
+          <button class="btn btn-primary btn-lg" id="btn_buscar">
             <i class="bi bi-search"></i> Buscar
           </button>
         </div>

--- a/vista/factura.js
+++ b/vista/factura.js
@@ -48,6 +48,7 @@ window.mostrarListarFacturas = mostrarListarFacturas;
 function wireListEvents(){
   $("#b_factura").off("input").on("input", debounce(cargarTablaFacturas, 250));
   $("#estado_lst").off("change").on("change", cargarTablaFacturas);
+  $("#desde_txt, #hasta_txt").off("change").on("change", cargarTablaFacturas);
   $("#btn_buscar").off("click").on("click", function(e){ e.preventDefault(); cargarTablaFacturas(); });
 }
 
@@ -453,8 +454,10 @@ function guardarFacturaCompleta(){
 function cargarTablaFacturas(){
   const buscar = $("#b_factura").val()||'';
   const estado = $("#estado_lst").val()||'';
+  const desde = $("#desde_txt").val()||'';
+  const hasta = $("#hasta_txt").val()||'';
   const js = ejecutarAjaxJSON("controladores/factura.php",
-    `leer=1&buscar=${encodeURIComponent(buscar)}&estado=${encodeURIComponent(estado)}`);
+    `leer=1&buscar=${encodeURIComponent(buscar)}&estado=${encodeURIComponent(estado)}&desde=${encodeURIComponent(desde)}&hasta=${encodeURIComponent(hasta)}`);
   const $tb = $("#tabla_facturas");
   $tb.html('');
 


### PR DESCRIPTION
## Summary
- add date range inputs and button id to sales invoice list UI
- pass selected dates to backend and reload on change
- support optional date range filtering in `factura.php`

## Testing
- `php -l controladores/factura.php`
- `php -l paginas/movimientos/venta/factura_venta/listar.php`
- `node --check vista/factura.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689d5c27ce088325bf5016e05e5a0506