### PR TITLE
Add print button and search/filter for services

### DIFF
--- a/controladores/servicio.php
+++ b/controladores/servicio.php
@@ -126,7 +126,21 @@ function guardar($lista){
 function leer(){
     header('Content-Type: application/json; charset=utf-8');
     try {
-        $pdo = getPDO();
+        $pdo   = getPDO();
+        $where = '';
+        $params = [];
+
+        if (!empty($_REQUEST['estado'])) {
+            $where .= ' AND s.estado = :estado';
+            $params[':estado'] = $_REQUEST['estado'];
+        }
+
+        if (!empty($_REQUEST['buscar'])) {
+            $b = '%'.$_REQUEST['buscar'].'%';
+            $where .= ' AND (c.nombre_cliente LIKE :b OR s.id_servicio LIKE :b)';
+            $params[':b'] = $b;
+        }
+
         $sql = "SELECT s.id_servicio,
                        s.fecha_servicio,
                        c.nombre_cliente AS cliente,
@@ -134,9 +148,10 @@ function leer(){
                        s.estado
                 FROM servicios s
                 JOIN cliente_1 c ON c.cod_cliente = s.id_cliente
+                WHERE 1=1 {$where}
                 ORDER BY s.id_servicio DESC";
         $q = $pdo->prepare($sql);
-        $q->execute();
+        $q->execute($params);
         $rows = $q->fetchAll(PDO::FETCH_OBJ);
         echo json_encode($rows ?: []);
     } catch (Throwable $e) {

--- a/paginas/movimientos/servicio/servicios/imprimir.php
+++ b/paginas/movimientos/servicio/servicios/imprimir.php
@@ -1,0 +1,95 @@
+<?php
+require_once dirname(__DIR__, 4) . '/conexion/db.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if ($id <= 0) { echo 'ID inválido'; exit; }
+
+$db  = new DB();
+$pdo = $db->conectar();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$sqlCab = "SELECT s.*, c.nombre_cliente, c.ruc, c.telefono
+            FROM servicios s
+            JOIN cliente_1 c ON c.cod_cliente = s.id_cliente
+            WHERE s.id_servicio = ?";
+$st = $pdo->prepare($sqlCab);
+$st->execute([$id]);
+$cab = $st->fetch(PDO::FETCH_OBJ);
+if(!$cab){ echo 'No encontrado'; exit; }
+
+$det = $pdo->prepare("SELECT * FROM servicio_detalles WHERE id_servicio=?");
+$det->execute([$id]);
+$detalles = $det->fetchAll(PDO::FETCH_OBJ);
+
+function fmt0($n){ return number_format((float)$n,0,',','.'); }
+?>
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Servicio #<?= htmlspecialchars($cab->id_servicio) ?></title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+<style>
+  body{ background:#f8f9fa }
+  .doc{ max-width:960px; margin:24px auto; background:#fff; padding:24px; border-radius:12px; box-shadow:0 6px 18px rgba(0,0,0,.06) }
+  .table th, .table td { vertical-align: middle; }
+</style>
+</head>
+<body onload="window.print();">
+  <div class="doc">
+    <div class="d-flex justify-content-between">
+      <h3 class="mb-3">SERVICIO #<?= htmlspecialchars($cab->id_servicio) ?></h3>
+      <div class="text-end">
+        <div><strong>Fecha:</strong> <?= htmlspecialchars($cab->fecha_servicio) ?></div>
+        <div><strong>Estado:</strong> <?= htmlspecialchars($cab->estado) ?></div>
+      </div>
+    </div>
+
+    <div class="mb-3">
+      <strong>Cliente:</strong> <?= htmlspecialchars($cab->nombre_cliente) ?> |
+      <strong>RUC:</strong> <?= htmlspecialchars($cab->ruc) ?> |
+      <strong>Tel:</strong> <?= htmlspecialchars($cab->telefono) ?>
+    </div>
+
+    <?php if ($detalles): ?>
+    <table class="table table-sm table-bordered">
+      <thead class="table-light">
+        <tr>
+          <th>Tipo</th>
+          <th>Descripción</th>
+          <th>Prod. Relacionado</th>
+          <th class="text-end" style="width:8%">Cant.</th>
+          <th class="text-end" style="width:12%">Precio</th>
+          <th class="text-end" style="width:12%">Subtotal</th>
+          <th>Obs.</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach($detalles as $d): ?>
+          <tr>
+            <td><?= htmlspecialchars($d->tipo_servicio) ?></td>
+            <td><?= htmlspecialchars($d->descripcion) ?></td>
+            <td><?= htmlspecialchars($d->producto_relacionado) ?></td>
+            <td class="text-end"><?= fmt0($d->cantidad) ?></td>
+            <td class="text-end"><?= fmt0($d->precio_unitario) ?></td>
+            <td class="text-end"><?= fmt0($d->subtotal) ?></td>
+            <td><?= htmlspecialchars($d->observaciones) ?></td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+    <?php endif; ?>
+
+    <div class="d-flex justify-content-end mt-4">
+      <table class="table w-auto">
+        <tr class="table-primary"><th class="text-end">TOTAL</th><td class="text-end fw-bold"><?= fmt0($cab->total) ?></td></tr>
+      </table>
+    </div>
+
+    <?php if (!empty($cab->observaciones)): ?>
+      <div class="mt-3"><strong>Observaciones:</strong> <?= nl2br(htmlspecialchars($cab->observaciones)) ?></div>
+    <?php endif; ?>
+  </div>
+</body>
+</html>
+

--- a/paginas/movimientos/servicio/servicios/listar.php
+++ b/paginas/movimientos/servicio/servicios/listar.php
@@ -37,7 +37,6 @@
             <option value="">Todos</option>
             <option value="PENDIENTE">Pendiente</option>
             <option value="EN PROCESO">En Proceso</option>
-            <option value="TERMINADO">Terminado</option>
             <option value="ANULADO">Anulado</option>
           </select>
           <small class="text-muted">Filtro opcional por estado</small>

--- a/vista/servicio.js
+++ b/vista/servicio.js
@@ -3,22 +3,31 @@
 function mostrarListarServicio(){
   const contenido = dameContenido("paginas/movimientos/servicio/servicios/listar.php");
   $(".contenido-principal").html(contenido);
+
+  $("#b_servicio").on("keypress", function(e){ if(e.which === 13) cargarTablaServicio(); });
+  $("#estado_lst_servicio").on("change", cargarTablaServicio);
+
   cargarTablaServicio();
 }
 
 function cargarTablaServicio(){
+  const buscar = $("#b_servicio").val()?.trim() || "";
+  const estado = $("#estado_lst_servicio").val() || "";
+
   $.ajax({
     url: "controladores/servicio.php",
     method: "POST",
-    data: { leer: 1 },
+    data: { leer: 1, buscar, estado },
     dataType: "json",
     success: function(lista){
       const $tb = $("#servicio_tb");
+      const $empty = $("#servicio_empty_state");
       $tb.empty();
       if (!Array.isArray(lista) || lista.length===0){
-        $tb.html("<tr><td colspan='6' class='text-center'>SIN REGISTROS</td></tr>");
+        $empty.removeClass("d-none");
         return;
       }
+      $empty.addClass("d-none");
       let filas = "";
       lista.forEach(item=>{
         filas += `<tr>
@@ -26,11 +35,13 @@ function cargarTablaServicio(){
           <td>${item.fecha_servicio}</td>
           <td class="text-start">${item.cliente || "-"}</td>
           <td class="text-end">${fmt0(item.total)}</td>
-          <td>${item.estado ?? ''}</td>
-
+          <td>${badgeEstado(item.estado)}</td>
           <td>
-            <button class='btn btn-sm btn-primary' onclick='editarServicio(${item.id_servicio}); return false;'>Editar</button>
-            <button class='btn btn-sm btn-danger' onclick='eliminarServicio(${item.id_servicio}); return false;'>Eliminar</button>
+            <div class="btn-group btn-group-sm" role="group">
+              <button class='btn btn-outline-secondary' onclick='imprimirServicio(${item.id_servicio}); return false;'>Imprimir</button>
+              <button class='btn btn-primary' onclick='editarServicio(${item.id_servicio}); return false;'>Editar</button>
+              <button class='btn btn-danger' onclick='eliminarServicio(${item.id_servicio}); return false;'>Eliminar</button>
+            </div>
           </td>
         </tr>`;
       });
@@ -41,6 +52,10 @@ function cargarTablaServicio(){
       $("#servicio_tb").html("<tr><td colspan='6' class='text-center'>ERROR</td></tr>");
     }
   });
+}
+
+function imprimirServicio(id){
+  window.open(`paginas/movimientos/servicio/servicios/imprimir.php?id=${encodeURIComponent(id)}`, "_blank", "noopener");
 }
 
 // ===== Agregar =====


### PR DESCRIPTION
## Summary
- Allow filtering services by search text and state, showing badges for statuses
- Add per-row print button and printable service template
- Update service list to use only Pendiente, En Proceso, and Anulado states

## Testing
- `php -l controladores/servicio.php`
- `php -l paginas/movimientos/servicio/servicios/imprimir.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e58656c9083259587ad6e88772c4f