### PR TITLE
fix: habilitar detalle y validar cantidades con formato

### DIFF
--- a/paginas/movimientos/servicio/servicios/agregar.php
+++ b/paginas/movimientos/servicio/servicios/agregar.php
@@ -75,11 +75,11 @@
     </div>
 
     <div class="col-md-1 mt-2">
-      <input type="number" id="cant_servicio" class="form-control" value="1" min="1" step="1" placeholder="Cant.">
+      <input type="text" id="cant_servicio" class="form-control text-end" value="1" placeholder="Cant.">
     </div>
 
     <div class="col-md-2 mt-2">
-      <input type="number" id="precio_servicio" class="form-control" placeholder="Precio" step="0.01" min="0">
+      <input type="text" id="precio_servicio" class="form-control text-end" placeholder="Precio">
     </div>
 
     <div class="col-md-1 mt-2">

--- a/vista/servicio.js
+++ b/vista/servicio.js
@@ -102,14 +102,19 @@ function mostrarAgregarServicio(){
   });
 }
 
-function agregarDetalle() {
-    const tipo    = ($("#tipo_servicio").val() || "").trim();
-    const desc    = ($("#desc_servicio").val() || "").trim();
-    const prodTxt = ($("#producto_rel_txt").val() || "").trim();
+  function agregarDetalle() {
+      const tipo    = ($("#tipo_servicio").val() || "").trim();
+      const desc    = ($("#desc_servicio").val() || "").trim();
+      const prodTxt = ($("#producto_rel_txt").val() || "").trim();
 
-    const cant    = parseFloat($("#cant_servicio").val());
-    const precio  = parseFloat($("#precio_servicio").val());
-    const obs     = ($("#obs_detalle").val() || "").trim();
+      // Permitir que los valores numéricos se carguen con separadores de miles
+      const toNum = v => parseFloat(String(v || "0")
+                                   .replace(/\s/g, "")
+                                   .replace(/\./g, "")
+                                   .replace(",", "."));
+      const cant    = toNum($("#cant_servicio").val());
+      const precio  = toNum($("#precio_servicio").val());
+      const obs     = ($("#obs_detalle").val() || "").trim();
 
     if (!prodTxt) { alert("Debes escribir el producto."); $("#producto_rel_txt").focus(); return; }
     if (!tipo)    { alert("Debes seleccionar el tipo."); $("#tipo_servicio").focus(); return; }


### PR DESCRIPTION
## Summary
- habilita los campos de cantidad y precio del detalle para permitir ingreso manual
- extiende el parser numérico para aceptar espacios y separadores evitando 'Cantidad inválida'

## Testing
- `node --check vista/servicio.js`
- `php -l paginas/movimientos/servicio/servicios/agregar.php`


------
https://chatgpt.com/codex/tasks/task_e_689e6305dd0083258749858b72965a5c